### PR TITLE
Fix GLSL compilation - "mix(vec4, vec3, float)" is not defined

### DIFF
--- a/data/2d_water.frag
+++ b/data/2d_water.frag
@@ -59,7 +59,7 @@ void main() {
 
   float wave = rd3.x * waveStrength;
   float nearSurface = clamp((1.0 - coord.y) + wave, 0.0, 1.0);
-  color += max(sign(foamThickness * 2.0 - nearSurface), 0.0) * mix(vec4(0.0), colorFoam, clamp(norm(coord.y, 1.0 - foamThickness * 0.5 - wave, 1.0), 0.0, 1.0));
+  color += max(sign(foamThickness * 2.0 - nearSurface), 0.0) * mix(vec3(0.0), colorFoam, clamp(norm(coord.y, 1.0 - foamThickness * 0.5 - wave, 1.0), 0.0, 1.0));
 
   gl_FragColor = max(sign(nearSurface - wave * 2.0), 0.0) * vec4(mix(color, refractColor, fadeRefract), 1.0);
 }


### PR DESCRIPTION
`2d_water.frag` fails to compile on one of my GPUs, 

```
  Version string: 3.0 Mesa 18.3.6
  Vendor: Intel Open Source Technology Center
  Renderer: Mesa DRI Intel(R) UHD Graphics 630 (Coffeelake 3x8 GT2) 
```

The error is

```
Warning: VRML/X3D: Cannot use GLSL shader for shape "IndexedFaceSet": Fragment shader not compiled:
0:62(63): error: no matching function for call to `mix(vec4, vec3, float)'; candidates are:
0:62(63): error:    float mix(float, float, float)
0:62(63): error:    vec2 mix(vec2, vec2, float)
0:62(63): error:    vec3 mix(vec3, vec3, float)
0:62(63): error:    vec4 mix(vec4, vec4, float)
0:62(63): error:    vec2 mix(vec2, vec2, vec2)
0:62(63): error:    vec3 mix(vec3, vec3, vec3)
0:62(63): error:    vec4 mix(vec4, vec4, vec4)
0:62(11): error: operands to arithmetic operators must be numeric
```

Indeed the line tries to lerp between vec4 and vec3. The trivial fix changes it to lerp between vec3 and vec3, which compiles OK.
